### PR TITLE
Adds paper size options to Typst show

### DIFF
--- a/_extensions/orange-book/typst-show.typ
+++ b/_extensions/orange-book/typst-show.typ
@@ -16,6 +16,15 @@ $endif$
 $if(lang)$
   lang: "$lang$",
 $endif$
+$if(papersize)$
+  paper-size: "$papersize$",
+$endif$
+$if(paper-width)$
+  width: $paper-width$,
+$endif$
+$if(paper-height)$
+  height: $paper-height$,
+$endif$
   main-color: brand-color.at("primary", default: blue),
   logo: {
     let logo-info = brand-logo.at("medium", default: none)


### PR DESCRIPTION
Adds the ability to specify paper size, width, and height
options when using the Typst show extension. This allows
for more control over the output document's dimensions.
