### PR TITLE
Fix running header chapter prefix when lang is non-English

### DIFF
--- a/_extensions/orange-book/typst-show.typ
+++ b/_extensions/orange-book/typst-show.typ
@@ -30,6 +30,9 @@ $endif$
 $if(lot)$
   list-of-table-title: "$if(crossref.lot-title)$$crossref.lot-title$$else$$crossref-lot-title$$endif$",
 $endif$
+$if(crossref-ch-prefix)$
+  supplement-chapter: "$crossref-ch-prefix$",
+$endif$
 $if(margin-geometry)$
   padded-heading-number: false,
 $endif$


### PR DESCRIPTION
When rendering a Typst book with `lang:` set to a non-English locale, the running header keeps the English `Chapter N.` prefix instead of the locale's word (e.g. `Chapitre N.` for `lang: fr`).

The `book()` function exposes a `supplement-chapter` parameter that drives the running header via a `show heading` rule, but `typst-show.typ` was not forwarding Quarto's localized chapter prefix variable.

The line is gated on the template variable being defined, so the default English `Chapter` supplied by `book()`'s own default applies when the variable is unset (e.g., Quarto versions that do not yet surface this metadata, or non-Quarto consumers of the template).

Refs quarto-dev/quarto-cli#14524