### PR TITLE
Migrate localized pipes to $quarto.language.* namespace

### DIFF
--- a/_extensions/orange-book/_extension.yml
+++ b/_extensions/orange-book/_extension.yml
@@ -1,6 +1,6 @@
 title: Typst Orange Book Format
 author: Quarto
-version: 0.1.0
+version: 0.2.0
 quarto-required: ">=1.9.17"
 contributes:
   formats:

--- a/_extensions/orange-book/typst-show.typ
+++ b/_extensions/orange-book/typst-show.typ
@@ -25,13 +25,25 @@ $if(toc-depth)$
   outline-depth: $toc-depth$,
 $endif$
 $if(lof)$
-  list-of-figure-title: "$if(crossref.lof-title)$$crossref.lof-title$$else$$crossref-lof-title$$endif$",
+$if(crossref.lof-title)$
+  list-of-figure-title: "$crossref.lof-title$",
+$else$
+$if(quarto.language.crossref-lof-title)$
+  list-of-figure-title: "$quarto.language.crossref-lof-title$",
+$endif$
+$endif$
 $endif$
 $if(lot)$
-  list-of-table-title: "$if(crossref.lot-title)$$crossref.lot-title$$else$$crossref-lot-title$$endif$",
+$if(crossref.lot-title)$
+  list-of-table-title: "$crossref.lot-title$",
+$else$
+$if(quarto.language.crossref-lot-title)$
+  list-of-table-title: "$quarto.language.crossref-lot-title$",
 $endif$
-$if(crossref-ch-prefix)$
-  supplement-chapter: "$crossref-ch-prefix$",
+$endif$
+$endif$
+$if(quarto.language.crossref-ch-prefix)$
+  supplement-chapter: "$quarto.language.crossref-ch-prefix$",
 $endif$
 $if(margin-geometry)$
   padded-heading-number: false,


### PR DESCRIPTION
Switches `supplement-chapter`, `list-of-figure-title`, and `list-of-table-title` template pipes to consume the new `$quarto.language.*$` Pandoc template-variable namespace introduced in [quarto-dev/quarto-cli#14530](https://github.com/quarto-dev/quarto-cli/pull/14530).

## Background

PR #3 wired `supplement-chapter: "$crossref-ch-prefix$"` to localize the running header. The flat `$crossref-ch-prefix$` form relied on Quarto copying the value into Pandoc YAML metadata. That mechanism leaked the key into rendered output for writers with `+yaml_metadata_block`, so quarto-cli replaced it with a non-leaking internal namespace.

The `list-of-figure-title` / `list-of-table-title` pipes have always used the same flat form in their `$else$` branches. Investigation against quarto-cli v1.9 source confirms those flat forms never resolved in Pandoc templates in any released Quarto version, so the pipes silently rendered as empty strings whenever `lof: true` / `lot: true` was set without a user `crossref:` override.

## Migration

All three pipes consume `$quarto.language.crossref-*$` instead. The user-override paths via the `crossref:` block (`$crossref.lof-title$` / `$crossref.lot-title$`) are preserved as the first cascade branch.

## Why nested `\$if(...)\$` for lof/lot (not for supplement-chapter)

The three pipes target two different parameters in `book()` (`lib.typ:311`):

- `supplement-chapter: "Chapter"` — string default. Outer `\$if(quarto.language.crossref-ch-prefix)\$` is enough: when the variable is unset (pre-#14530 Quarto, non-Quarto consumers), the whole block is skipped, no arg passes, `book()` uses its English literal default `"Chapter"`.
- `list-of-figure-title: none` / `list-of-table-title: none` — `none` default. The previous else-branch (`\$else\$\$quarto.language.crossref-lof-title\$\$endif\$`) would render an empty string when the variable was unset, sending `list-of-figure-title: ""` to `book()`. Empty string is NOT the same as `none`: `book()` passes the value as `title:` to Typst's `outline()` (`my-outline.typ:121`), so `""` produces an outline header with empty whitespace, while `none` produces an outline with no header at all (`book()`'s intended default).

Nested `\$if(...)\$` guards skip the `list-of-figure-title:` / `list-of-table-title:` arg entirely when `\$quarto.language.crossref-lof-title\$` / `\$quarto.language.crossref-lot-title\$` are unset, so `book()` falls back to its `none` default — strictly cleaner than empty-string for pre-#14530 consumers.

## Compatibility

Requires Quarto with the merged https://github.com/quarto-dev/quarto-cli/pull/14530 (1.10 dev or later) to localize. Earlier Quarto versions still render correctly — `supplement-chapter` falls back to English \"Chapter\", and the LOF/LOT outlines render without a title header (same as `book()`'s built-in behavior when no title arg is passed).